### PR TITLE
Clear audio buffer after seeking in a song.

### DIFF
--- a/src/main/java/com/fastbootmobile/encore/service/PlaybackService.java
+++ b/src/main/java/com/fastbootmobile/encore/service/PlaybackService.java
@@ -1031,6 +1031,7 @@ public class PlaybackService extends Service
                         provider.seek(timeMs);
                         success = true;
                         mCurrentTrackElapsedMs = timeMs;
+                        mNativeSink.flushSamples();
                     } catch (RemoteException e) {
                         Log.e(TAG, "Cannot seek to time", e);
                     } catch (Exception e) {


### PR DESCRIPTION
It creates a weird and unintuitive experience if the song continues
to play for a few seconds from the old position after the user already skipped forward to a new position.
