### PR TITLE
Theme Chooser Redirections 2

### DIFF
--- a/src/main/java/com/fastbootmobile/encore/app/adapters/NavDrawerAdapter.java
+++ b/src/main/java/com/fastbootmobile/encore/app/adapters/NavDrawerAdapter.java
@@ -146,7 +146,7 @@ public class NavDrawerAdapter extends BaseAdapter {
 
         if (isActiveEntry(i)) {
             tag.tvText.setTextColor(tag.tvText.getResources().getColor(R.color.primary));
-            view.setBackgroundColor(getColor(R.color.navdrawer_selected));
+            view.setBackgroundColor(getResources().getColor(R.color.navdrawer_selected));
         } else if (tag.tvText != null) {
             tag.tvText.setTextColor(tag.tvText.getResources().getColor(R.color.text_regular));
             int[] attrs = new int[] { android.R.attr.selectableItemBackground };

--- a/src/main/java/com/fastbootmobile/encore/app/adapters/NavDrawerAdapter.java
+++ b/src/main/java/com/fastbootmobile/encore/app/adapters/NavDrawerAdapter.java
@@ -146,7 +146,7 @@ public class NavDrawerAdapter extends BaseAdapter {
 
         if (isActiveEntry(i)) {
             tag.tvText.setTextColor(tag.tvText.getResources().getColor(R.color.primary));
-            view.setBackgroundColor(0xFFEAEAEA);
+            view.setBackgroundColor(getColor(R.color.navdrawer_selected));
         } else if (tag.tvText != null) {
             tag.tvText.setTextColor(tag.tvText.getResources().getColor(R.color.text_regular));
             int[] attrs = new int[] { android.R.attr.selectableItemBackground };

--- a/src/main/java/com/fastbootmobile/encore/app/ui/AnimatedMicButton.java
+++ b/src/main/java/com/fastbootmobile/encore/app/ui/AnimatedMicButton.java
@@ -89,13 +89,13 @@ public class AnimatedMicButton extends ImageButton {
         public void draw(Canvas canvas) {
             Rect bounds = getBounds();
 
-            mPaint.setColor(0xFFDDDDDD);
+            mPaint.setColor(getResources().getColor.(R.color.voice_pulse));
 
             canvas.drawCircle(bounds.centerX(), bounds.centerY(),
                     bounds.height() / 1.5f + mCurrentLevel * bounds.height() / 3.0f,
                     mPaint);
 
-            mPaint.setColor(0xFFFFFFFF);
+            mPaint.setColor(getResources().getColor.(R.color.white_background));
 
             canvas.drawCircle(bounds.centerX(), bounds.centerY(),
                     bounds.height() / 1.5f,

--- a/src/main/res/drawable-v21/playing_bar_item_background.xml
+++ b/src/main/res/drawable-v21/playing_bar_item_background.xml
@@ -2,7 +2,7 @@
 <ripple xmlns:android="http://schemas.android.com/apk/res/android" android:color="@color/primary_light">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/white" />
+            <solid android:color="@color/white_background" />
         </shape>
     </item>
 </ripple>

--- a/src/main/res/drawable/card_foreground_action.xml
+++ b/src/main/res/drawable/card_foreground_action.xml
@@ -3,10 +3,10 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true"
         android:state_focused="true"
-        android:color="@color/white"/>
+        android:color="@color/white_text"/>
     <item android:state_pressed="true"
         android:state_focused="false"
-        android:color="@color/white"/>
+        android:color="@color/white_text"/>
 
     <item android:color="@color/text_action" />
 </selector>

--- a/src/main/res/drawable/playing_bar_item_background.xml
+++ b/src/main/res/drawable/playing_bar_item_background.xml
@@ -7,7 +7,7 @@
     </item>
         <item>
             <shape android:shape="rectangle">
-                <solid android:color="@color/white" />
+                <solid android:color="@color/white_background" />
             </shape>
         </item>
     </selector>

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -26,7 +26,7 @@
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="?attr/colorPrimary"
+                android:background="@color/red_bg"
                 android:minHeight="?attr/actionBarSize"
                 android:paddingTop="@dimen/translucent_toolbar_top_margin"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light"

--- a/src/main/res/layout/activity_playback_queue.xml
+++ b/src/main/res/layout/activity_playback_queue.xml
@@ -10,7 +10,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimary"
+        android:background="@color/red_bg"
         android:minHeight="?attr/actionBarSize"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>

--- a/src/main/res/layout/activity_search.xml
+++ b/src/main/res/layout/activity_search.xml
@@ -11,7 +11,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimary"
+        android:background="@color/red_bg"
         android:minHeight="?attr/actionBarSize"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>

--- a/src/main/res/layout/activity_settings.xml
+++ b/src/main/res/layout/activity_settings.xml
@@ -10,7 +10,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimary"
+        android:background="@color/red_bg"
         android:minHeight="?attr/actionBarSize"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>

--- a/src/main/res/layout/fragment_artist.xml
+++ b/src/main/res/layout/fragment_artist.xml
@@ -25,7 +25,7 @@
             android:transitionName="artistName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="@color/text_regular"
+            android:background="@color/artist_bg"
             android:gravity="top|start"
             android:paddingTop="@dimen/entview_head_padding_top"
             android:paddingBottom="@dimen/artist_head_padding_bottom"

--- a/src/main/res/layout/fragment_my_songs.xml
+++ b/src/main/res/layout/fragment_my_songs.xml
@@ -10,7 +10,7 @@
         android:id="@+id/pager_title_strip"
         android:layout_width="match_parent"
         android:layout_height="@dimen/my_songs_strip_height"
-        android:background="@color/primary"
+        android:background="@color/red_bg"
         android:clipToPadding="false"
         android:paddingTop="@dimen/translucent_toolbarstatus_top_margin"
         app:stl_indicatorAlwaysInCenter="false"

--- a/src/main/res/layout/fragment_navigation_drawer.xml
+++ b/src/main/res/layout/fragment_navigation_drawer.xml
@@ -2,7 +2,7 @@
           xmlns:android="http://schemas.android.com/apk/res/android"
           android:layout_width="match_parent"
           android:layout_height="fill_parent"
-          android:background="@color/white"
+          android:background="@color/white_background"
           android:choiceMode="singleChoice"
           android:divider="@null"
           android:dividerHeight="0dp"

--- a/src/main/res/layout/fragment_playing_bar.xml
+++ b/src/main/res/layout/fragment_playing_bar.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/playing_bar_margin_top"
         android:elevation="@dimen/playing_bar_elevation"
-        android:background="@color/white"
+        android:background="@color/white_background"
         android:orientation="vertical">
 
     </LinearLayout>

--- a/src/main/res/layout/header_listview_songs.xml
+++ b/src/main/res/layout/header_listview_songs.xml
@@ -19,7 +19,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/primary"
+        android:background="@color/red_bg"
         android:layout_below="@+id/tvAlbumName"
         android:id="@+id/layoutBar"
         android:visibility="gone"
@@ -101,7 +101,7 @@
         android:layout_height="wrap_content"
         android:layout_alignLeft="@+id/ivHero"
         android:layout_alignStart="@+id/ivHero"
-        android:background="@color/text_regular"
+        android:background="@color/artist_bg"
         android:transitionName="albumName"
         android:textAppearance="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
         fontPath="fonts/Roboto-Medium.ttf"

--- a/src/main/res/layout/item_playlist_view.xml
+++ b/src/main/res/layout/item_playlist_view.xml
@@ -14,7 +14,7 @@
         android:id="@+id/currentSongIndicator"
         android:layout_width="4dp"
         android:layout_height="match_parent"
-        android:background="@color/primary"
+        android:background="@color/red_bg"
         android:visibility="invisible" />
 
     <com.fastbootmobile.encore.app.ui.AlbumArtImageView

--- a/src/main/res/layout/medium_card_two_lines.xml
+++ b/src/main/res/layout/medium_card_two_lines.xml
@@ -53,7 +53,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:gravity="start|top"
-                android:textColor="@color/white"
+                android:textColor="@color/white_text"
                 android:paddingTop="4dp"
                 android:layout_weight="1"
                 android:layout_gravity="top"

--- a/src/main/res/layout/toolbar_automix.xml
+++ b/src/main/res/layout/toolbar_automix.xml
@@ -3,6 +3,6 @@
                                    xmlns:app="http://schemas.android.com/apk/res-auto"
                                    android:layout_width="match_parent"
                                    android:layout_height="wrap_content"
-                                   android:background="@color/primary"
+                                   android:background="@color/red_bg"
                                    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
                                    app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>

--- a/src/main/res/layout/toolbar_settings.xml
+++ b/src/main/res/layout/toolbar_settings.xml
@@ -8,7 +8,7 @@
     android:layout_height="wrap_content"
     android:minHeight="?attr/actionBarSize"
     app:navigationContentDescription="@string/abc_action_bar_up_description"
-    android:background="?attr/colorPrimary"
+    android:background="@color/red_bg"
     app:navigationIcon="?attr/homeAsUpIndicator"
     app:title="@string/action_settings"
     />

--- a/src/main/res/values/colors_apptheme.xml
+++ b/src/main/res/values/colors_apptheme.xml
@@ -78,7 +78,10 @@
 	<color name="shadow_startColor">#aa777777</color>
 	<color name="notification_bg">@color/material_blue_grey_900</color>
 	<color name="material_blue_grey_800">#ff37474f</color>
-    <color name="material_blue_grey_900">#ff263238</color>
+    	<color name="material_blue_grey_900">#ff263238</color>
+	<color name="artist_bg">#333333</color>
+	<color name="red_bg">#F44336</color>
+	<color name="white_background">#ffffffff</color>
 	
 	
 	

--- a/src/main/res/values/colors_apptheme.xml
+++ b/src/main/res/values/colors_apptheme.xml
@@ -83,7 +83,7 @@
 	<color name="red_bg">#F44336</color>
 	<color name="white_background">#ffffffff</color>
 	<color name="navdrawer_selected">#FFEAEAEA</color>
-	
+	<color name="voice_pulse">#ffdddddd</color>
 	
 	
 </resources>

--- a/src/main/res/values/colors_apptheme.xml
+++ b/src/main/res/values/colors_apptheme.xml
@@ -78,10 +78,11 @@
 	<color name="shadow_startColor">#aa777777</color>
 	<color name="notification_bg">@color/material_blue_grey_900</color>
 	<color name="material_blue_grey_800">#ff37474f</color>
-    	<color name="material_blue_grey_900">#ff263238</color>
+    <color name="material_blue_grey_900">#ff263238</color>
 	<color name="artist_bg">#333333</color>
 	<color name="red_bg">#F44336</color>
 	<color name="white_background">#ffffffff</color>
+	<color name="navdrawer_selected">#FFEAEAEA</color>
 	
 	
 	


### PR DESCRIPTION
Redirections of backgrounds/text from @color/white to
@color/white_background or @color/white_text - so that the PlayPause
icon, textColor, and indicatorColor is not affected when trying to invert backgrounds.
Also redirected backgrounds in layouts using ?attr/colorPrimary and
@color/primary to a new color (same hex as @color/primary), due to
lollipop requirements of colorPrimary being opaque. This helps themers
that use Wallpaper styles/attributes.
